### PR TITLE
commented out Torch in .cfg file and added instruction in README to pip install Torch dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,10 +7,22 @@ Installation
 To download this code and install in development mode, do the following:
 
 .. code-block::
-
+    
+    $ fork a copy
     $ git clone https://github.com/CoronaWhy/drug-lit-contradictory-claims.git
     $ cd drug-lit-contradictory-claims
     $ pip install -e .
+    
+Dependencies
+------------
+.. code-block::
+
+    $ pip install Torch:
+       - Windows - pip install torch===1.6.0 torchvision===0.7.0 -f https://download.pytorch.org/whl/torch_stable.html
+       - Mac - pip install torch torchvision 
+            # MacOS Binaries dont support CUDA, install from source (https://pytorch.org/) if CUDA is needed
+       - Linux - pip install torch torchvision
+
 
 Testing |build| |coverage|
 --------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     scikit-learn
 	scispacy
     tensorflow
-    torch
+    #torch
     transformers
     wandb==0.9.4
     # python-s3 @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_core_sci_lg-0.2.4.tar.gz


### PR DESCRIPTION
Installing Torch through setup.cfg via setuptools throws an error. As far as I can tell, PyPi and by default setuptools stopped supporting Torch after the initial release so it needs to be installed from the PyTorch website. Then there are options for with and without CUDA for windows, mac and linux so building that logic into the .cfg file at present is likely an unnecessary time-sink.